### PR TITLE
limit Travis test on stable haxe version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: haxe
 
+# haxe versions : http://haxe.org/website-content/downloads/versions.json
 haxe:
-- 3.2.1
-- development
+  - "3.2.1"
+  - "3.3.0-rc.1"
+  - development
 
+matrix:
+  allow_failures:
+  - haxe: development
+    
 addons:
   apt:
     packages:


### PR DESCRIPTION
- add haxe "3.3.0-rc.1" target
- allow failures for haxe development
